### PR TITLE
Do not loop on modreload

### DIFF
--- a/suspend-modules
+++ b/suspend-modules
@@ -75,9 +75,7 @@ case $1 in
         done
     ;;
     post)
-        for mod in $(</etc/suspend-modules.conf); do
-            modreload $mod
-        done
-        rm -f "${STORAGEDIR}/*"
+        modreload
+        rm -rf "${STORAGEDIR}"
     ;;
 esac


### PR DESCRIPTION
Modreload is already looping through unloaded modules so there's no need to execute it multiple times